### PR TITLE
Rename some options for consistency.

### DIFF
--- a/src/Classes/Database.php
+++ b/src/Classes/Database.php
@@ -121,8 +121,8 @@ class Database
 			$dumper = $dumper->setHost($connection['host']);
 		}
 
-		if (self::optionIsSet('dump_binary_path') && method_exists($dumper, 'setDumpBinaryPath')) {
-			$dumper = $dumper->setDumpBinaryPath(self::getOption('dump_binary_path'));
+		if (self::optionIsSet('dumpBinaryPath') && method_exists($dumper, 'setDumpBinaryPath')) {
+			$dumper = $dumper->setDumpBinaryPath(self::getOption('dumpBinaryPath'));
 		}
 
 		if (self::optionIsSet('timeout') && method_exists($dumper, 'setTimeout')) {
@@ -140,8 +140,8 @@ class Database
 		if (method_exists($dumper, 'setSocket')) {
 			if (!empty($connection['unix_socket'])) {
 				$dumper = $dumper->setSocket($connection['unix_socket']);
-			} else if (self::optionIsSet('unix_socket')) {
-				$dumper = $dumper->setSocket(self::getOption('unix_socket'));
+			} else if (self::optionIsSet('unixSocket')) {
+				$dumper = $dumper->setSocket(self::getOption('unixSocket'));
 			}
 		}
 

--- a/src/Lumen/Config.php
+++ b/src/Lumen/Config.php
@@ -36,9 +36,7 @@ class Config
 	{
 		if (
 			$connection['driver'] &&
-			$connection['host'] &&
-			$connection['database'] &&
-			$connection['username']
+			$connection['database']
 		) {
 			return true;
 		}

--- a/src/config/centinelApi.php
+++ b/src/config/centinelApi.php
@@ -41,16 +41,16 @@ return [
 
 	'database' => [
 		'connection' => '{default}',
-		'dump_binary_path' => null,
+		'dumpBinaryPath' => null,
 		'timeout' => 120,
 
 		// MySQL, PostgreSQL, MongoDB
 		'port' => null, // can be overridden through /config/database.php config file
 
 		// MySQL, PostgreSQL
-		'unix_socket' => null, // can be overridden through /config/database.php config file
-		'includeTables' => null, // array
-		'excludeTables' => null, // array
+		'unixSocket' => null, // can be overridden with 'unix_socket' in /config/database.php config file
+		'includeTables' => null, // null or array
+		'excludeTables' => null, // null or array
 
 		// MySQL
 		'dontSkipComments' => null, // null or true
@@ -58,7 +58,7 @@ return [
 		'useSingleTransaction' => null, // null or true
 		'defaultCharacterSet' => null,
 		'gtidPurged' => null,
-		'extraOptions' => null, // array
+		'extraOptions' => null, // null or array
 
 		// PostgreSQL
 		'useInserts' => null, // null or true


### PR DESCRIPTION
Remove 'host' and 'username' from connection data validation.